### PR TITLE
fix(HowToGuides): provide correct releases links in installation

### DIFF
--- a/Documentation/HowToGuides/Installation/README.md
+++ b/Documentation/HowToGuides/Installation/README.md
@@ -64,5 +64,5 @@ The package will now also show up in the Unity Package Manager UI. From then on 
 [Unity Package Manager]: https://docs.unity3d.com/Manual/upm-ui.html
 [Project-Manifest]: https://docs.unity3d.com/Manual/upm-manifestPrj.html
 [Version-Release]: https://img.shields.io/github/release/ExtendRealityLtd/Tilia.Input.CombinedActions.Unity.svg
-[Releases]: ../../releases
-[Latest-Release]: ../../releases/latest
+[Releases]: ../../../../../releases
+[Latest-Release]: ../../../../../releases/latest


### PR DESCRIPTION
The Installation How To Guide now has the correct links to the
releases and latest releases path.