### PR TITLE
feat(Actions): change unsupported properties via UnityEvents

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -4,7 +4,6 @@ update_configs:
     directory: /
     update_schedule: live
     default_reviewers:
-      - bddckr
       - thestonefox
     default_labels:
       - dependency-update

--- a/Documentation/API/AngleRangeToBooleanFacade.md
+++ b/Documentation/API/AngleRangeToBooleanFacade.md
@@ -22,6 +22,13 @@ The public interface into the AngleRangeToBoolean Prefab.
   * [OnAfterUnitTypeChange()]
   * [OnAfterVerticalAxisChange()]
   * [OnAfterVerticalDeadzoneChange()]
+  * [SetAngleRangeMaximum(Single)]
+  * [SetAngleRangeMinimum(Single)]
+  * [SetHorizontalDeadzoneMaximum(Single)]
+  * [SetHorizontalDeadzoneMinimum(Single)]
+  * [SetUnitType(Int32)]
+  * [SetVerticalDeadzoneMaximum(Single)]
+  * [SetVerticalDeadzoneMinimum(Single)]
 
 ## Details
 
@@ -174,6 +181,118 @@ Called after [VerticalDeadzone] has been changed.
 protected virtual void OnAfterVerticalDeadzoneChange()
 ```
 
+#### SetAngleRangeMaximum(Single)
+
+Sets the [AngleRange] maximum value.
+
+##### Declaration
+
+```
+public virtual void SetAngleRangeMaximum(float value)
+```
+
+##### Parameters
+
+| Type | Name | Description |
+| --- | --- | --- |
+| System.Single | value | The new maximum value. |
+
+#### SetAngleRangeMinimum(Single)
+
+Sets the [AngleRange] minimum value.
+
+##### Declaration
+
+```
+public virtual void SetAngleRangeMinimum(float value)
+```
+
+##### Parameters
+
+| Type | Name | Description |
+| --- | --- | --- |
+| System.Single | value | The new minimum value. |
+
+#### SetHorizontalDeadzoneMaximum(Single)
+
+Sets the [HorizontalDeadzone] maximum value.
+
+##### Declaration
+
+```
+public virtual void SetHorizontalDeadzoneMaximum(float value)
+```
+
+##### Parameters
+
+| Type | Name | Description |
+| --- | --- | --- |
+| System.Single | value | The new maximum value. |
+
+#### SetHorizontalDeadzoneMinimum(Single)
+
+Sets the [HorizontalDeadzone] minimum value.
+
+##### Declaration
+
+```
+public virtual void SetHorizontalDeadzoneMinimum(float value)
+```
+
+##### Parameters
+
+| Type | Name | Description |
+| --- | --- | --- |
+| System.Single | value | The new minimum value. |
+
+#### SetUnitType(Int32)
+
+Sets [UnitType].
+
+##### Declaration
+
+```
+public virtual void SetUnitType(int unitTypeIndex)
+```
+
+##### Parameters
+
+| Type | Name | Description |
+| --- | --- | --- |
+| System.Int32 | unitTypeIndex | The index of the Vector2ToAngle.AngleUnit. |
+
+#### SetVerticalDeadzoneMaximum(Single)
+
+Sets the [VerticalDeadzone] maximum value.
+
+##### Declaration
+
+```
+public virtual void SetVerticalDeadzoneMaximum(float value)
+```
+
+##### Parameters
+
+| Type | Name | Description |
+| --- | --- | --- |
+| System.Single | value | The new maximum value. |
+
+#### SetVerticalDeadzoneMinimum(Single)
+
+Sets the [VerticalDeadzone] minimum value.
+
+##### Declaration
+
+```
+public virtual void SetVerticalDeadzoneMinimum(float value)
+```
+
+##### Parameters
+
+| Type | Name | Description |
+| --- | --- | --- |
+| System.Single | value | The new minimum value. |
+
 [Tilia.Input.CombinedActions]: README.md
 [AngleRangeToBooleanConfigurator]: AngleRangeToBooleanConfigurator.md
 [AngleRange]: AngleRangeToBooleanFacade.md#AngleRange
@@ -181,6 +300,13 @@ protected virtual void OnAfterVerticalDeadzoneChange()
 [HorizontalDeadzone]: AngleRangeToBooleanFacade.md#HorizontalDeadzone
 [UnitType]: AngleRangeToBooleanFacade.md#UnitType
 [VerticalAxis]: AngleRangeToBooleanFacade.md#VerticalAxis
+[VerticalDeadzone]: AngleRangeToBooleanFacade.md#VerticalDeadzone
+[AngleRange]: AngleRangeToBooleanFacade.md#AngleRange
+[AngleRange]: AngleRangeToBooleanFacade.md#AngleRange
+[HorizontalDeadzone]: AngleRangeToBooleanFacade.md#HorizontalDeadzone
+[HorizontalDeadzone]: AngleRangeToBooleanFacade.md#HorizontalDeadzone
+[UnitType]: AngleRangeToBooleanFacade.md#UnitType
+[VerticalDeadzone]: AngleRangeToBooleanFacade.md#VerticalDeadzone
 [VerticalDeadzone]: AngleRangeToBooleanFacade.md#VerticalDeadzone
 [Inheritance]: #Inheritance
 [Namespace]: #Namespace
@@ -200,3 +326,10 @@ protected virtual void OnAfterVerticalDeadzoneChange()
 [OnAfterUnitTypeChange()]: #OnAfterUnitTypeChange
 [OnAfterVerticalAxisChange()]: #OnAfterVerticalAxisChange
 [OnAfterVerticalDeadzoneChange()]: #OnAfterVerticalDeadzoneChange
+[SetAngleRangeMaximum(Single)]: #SetAngleRangeMaximumSingle
+[SetAngleRangeMinimum(Single)]: #SetAngleRangeMinimumSingle
+[SetHorizontalDeadzoneMaximum(Single)]: #SetHorizontalDeadzoneMaximumSingle
+[SetHorizontalDeadzoneMinimum(Single)]: #SetHorizontalDeadzoneMinimumSingle
+[SetUnitType(Int32)]: #SetUnitTypeInt32
+[SetVerticalDeadzoneMaximum(Single)]: #SetVerticalDeadzoneMaximumSingle
+[SetVerticalDeadzoneMinimum(Single)]: #SetVerticalDeadzoneMinimumSingle

--- a/Documentation/API/AxesToAngleAction.md
+++ b/Documentation/API/AxesToAngleAction.md
@@ -19,6 +19,10 @@
   * [OnAfterVerticalAxisChange()]
   * [OnAfterVerticalDeadzoneChange()]
   * [OnEnable()]
+  * [SetHorizontalDeadzoneMaximum(Single)]
+  * [SetHorizontalDeadzoneMinimum(Single)]
+  * [SetVerticalDeadzoneMaximum(Single)]
+  * [SetVerticalDeadzoneMinimum(Single)]
 
 ## Details
 
@@ -159,12 +163,80 @@ protected virtual void OnAfterVerticalDeadzoneChange()
 protected override void OnEnable()
 ```
 
+#### SetHorizontalDeadzoneMaximum(Single)
+
+Sets the [HorizontalDeadzone] maximum value.
+
+##### Declaration
+
+```
+public virtual void SetHorizontalDeadzoneMaximum(float value)
+```
+
+##### Parameters
+
+| Type | Name | Description |
+| --- | --- | --- |
+| System.Single | value | The new maximum value. |
+
+#### SetHorizontalDeadzoneMinimum(Single)
+
+Sets the [HorizontalDeadzone] minimum value.
+
+##### Declaration
+
+```
+public virtual void SetHorizontalDeadzoneMinimum(float value)
+```
+
+##### Parameters
+
+| Type | Name | Description |
+| --- | --- | --- |
+| System.Single | value | The new minimum value. |
+
+#### SetVerticalDeadzoneMaximum(Single)
+
+Sets the [VerticalDeadzone] maximum value.
+
+##### Declaration
+
+```
+public virtual void SetVerticalDeadzoneMaximum(float value)
+```
+
+##### Parameters
+
+| Type | Name | Description |
+| --- | --- | --- |
+| System.Single | value | The new maximum value. |
+
+#### SetVerticalDeadzoneMinimum(Single)
+
+Sets the [VerticalDeadzone] minimum value.
+
+##### Declaration
+
+```
+public virtual void SetVerticalDeadzoneMinimum(float value)
+```
+
+##### Parameters
+
+| Type | Name | Description |
+| --- | --- | --- |
+| System.Single | value | The new minimum value. |
+
 [Tilia.Input.CombinedActions]: README.md
 [AxesToAngleActionConfigurator]: AxesToAngleActionConfigurator.md
 [DirectionOffset]: AxesToAngleAction.md#DirectionOffset
 [HorizontalAxis]: AxesToAngleAction.md#HorizontalAxis
 [HorizontalDeadzone]: AxesToAngleAction.md#HorizontalDeadzone
 [VerticalAxis]: AxesToAngleAction.md#VerticalAxis
+[VerticalDeadzone]: AxesToAngleAction.md#VerticalDeadzone
+[HorizontalDeadzone]: AxesToAngleAction.md#HorizontalDeadzone
+[HorizontalDeadzone]: AxesToAngleAction.md#HorizontalDeadzone
+[VerticalDeadzone]: AxesToAngleAction.md#VerticalDeadzone
 [VerticalDeadzone]: AxesToAngleAction.md#VerticalDeadzone
 [Inheritance]: #Inheritance
 [Namespace]: #Namespace
@@ -183,3 +255,7 @@ protected override void OnEnable()
 [OnAfterVerticalAxisChange()]: #OnAfterVerticalAxisChange
 [OnAfterVerticalDeadzoneChange()]: #OnAfterVerticalDeadzoneChange
 [OnEnable()]: #OnEnable
+[SetHorizontalDeadzoneMaximum(Single)]: #SetHorizontalDeadzoneMaximumSingle
+[SetHorizontalDeadzoneMinimum(Single)]: #SetHorizontalDeadzoneMinimumSingle
+[SetVerticalDeadzoneMaximum(Single)]: #SetVerticalDeadzoneMaximumSingle
+[SetVerticalDeadzoneMinimum(Single)]: #SetVerticalDeadzoneMinimumSingle

--- a/Documentation/API/AxesToVector3Action.md
+++ b/Documentation/API/AxesToVector3Action.md
@@ -29,9 +29,17 @@ Converts a lateral, vertical and longitudinal float representation into a Vector
   * [OnAfterVerticalAxisChange()]
   * [OnAfterVerticalDeadzoneChange()]
   * [OnEnable()]
+  * [SetInputType(Int32)]
+  * [SetLateralDeadzoneMaximum(Single)]
+  * [SetLateralDeadzoneMinimum(Single)]
+  * [SetLongitudinalDeadzoneMaximum(Single)]
+  * [SetLongitudinalDeadzoneMinimum(Single)]
   * [SetMultiplierX(Single)]
   * [SetMultiplierY(Single)]
   * [SetMultiplierZ(Single)]
+  * [SetTimeMultiplier(Int32)]
+  * [SetVerticalDeadzoneMaximum(Single)]
+  * [SetVerticalDeadzoneMinimum(Single)]
 
 ## Details
 
@@ -252,6 +260,86 @@ protected virtual void OnAfterVerticalDeadzoneChange()
 protected override void OnEnable()
 ```
 
+#### SetInputType(Int32)
+
+Sets [InputType].
+
+##### Declaration
+
+```
+public virtual void SetInputType(int inputTypeIndex)
+```
+
+##### Parameters
+
+| Type | Name | Description |
+| --- | --- | --- |
+| System.Int32 | inputTypeIndex | The index of the [AxesToVector3Action.InputHandler]. |
+
+#### SetLateralDeadzoneMaximum(Single)
+
+Sets the [LateralDeadzone] maximum value.
+
+##### Declaration
+
+```
+public virtual void SetLateralDeadzoneMaximum(float value)
+```
+
+##### Parameters
+
+| Type | Name | Description |
+| --- | --- | --- |
+| System.Single | value | The new maximum value. |
+
+#### SetLateralDeadzoneMinimum(Single)
+
+Sets the [LateralDeadzone] minimum value.
+
+##### Declaration
+
+```
+public virtual void SetLateralDeadzoneMinimum(float value)
+```
+
+##### Parameters
+
+| Type | Name | Description |
+| --- | --- | --- |
+| System.Single | value | The new minimum value. |
+
+#### SetLongitudinalDeadzoneMaximum(Single)
+
+Sets the [LongitudinalDeadzone] maximum value.
+
+##### Declaration
+
+```
+public virtual void SetLongitudinalDeadzoneMaximum(float value)
+```
+
+##### Parameters
+
+| Type | Name | Description |
+| --- | --- | --- |
+| System.Single | value | The new maximum value. |
+
+#### SetLongitudinalDeadzoneMinimum(Single)
+
+Sets the [LongitudinalDeadzone] minimum value.
+
+##### Declaration
+
+```
+public virtual void SetLongitudinalDeadzoneMinimum(float value)
+```
+
+##### Parameters
+
+| Type | Name | Description |
+| --- | --- | --- |
+| System.Single | value | The new minimum value. |
+
 #### SetMultiplierX(Single)
 
 Sets the [Multiplier] x value.
@@ -300,9 +388,56 @@ public virtual void SetMultiplierZ(float value)
 | --- | --- | --- |
 | System.Single | value | The value to set to. |
 
+#### SetTimeMultiplier(Int32)
+
+Sets [TimeMultiplier].
+
+##### Declaration
+
+```
+public virtual void SetTimeMultiplier(int timeMultiplierIndex)
+```
+
+##### Parameters
+
+| Type | Name | Description |
+| --- | --- | --- |
+| System.Int32 | timeMultiplierIndex | The index of the TimeComponentExtractor.TimeComponent. |
+
+#### SetVerticalDeadzoneMaximum(Single)
+
+Sets the [VerticalDeadzone] maximum value.
+
+##### Declaration
+
+```
+public virtual void SetVerticalDeadzoneMaximum(float value)
+```
+
+##### Parameters
+
+| Type | Name | Description |
+| --- | --- | --- |
+| System.Single | value | The new maximum value. |
+
+#### SetVerticalDeadzoneMinimum(Single)
+
+Sets the [VerticalDeadzone] minimum value.
+
+##### Declaration
+
+```
+public virtual void SetVerticalDeadzoneMinimum(float value)
+```
+
+##### Parameters
+
+| Type | Name | Description |
+| --- | --- | --- |
+| System.Single | value | The new minimum value. |
+
 [Tilia.Input.CombinedActions]: README.md
 [AxesToVector3ActionConfigurator]: AxesToVector3ActionConfigurator.md
-[AxesToVector3Action.InputHandler]: AxesToVector3Action.InputHandler.md
 [InputType]: AxesToVector3Action.md#InputType
 [LateralAxis]: AxesToVector3Action.md#LateralAxis
 [LateralDeadzone]: AxesToVector3Action.md#LateralDeadzone
@@ -312,9 +447,18 @@ public virtual void SetMultiplierZ(float value)
 [TimeMultiplier]: AxesToVector3Action.md#TimeMultiplier
 [VerticalAxis]: AxesToVector3Action.md#VerticalAxis
 [VerticalDeadzone]: AxesToVector3Action.md#VerticalDeadzone
+[InputType]: AxesToVector3Action.md#InputType
+[AxesToVector3Action.InputHandler]: AxesToVector3Action.InputHandler.md
+[LateralDeadzone]: AxesToVector3Action.md#LateralDeadzone
+[LateralDeadzone]: AxesToVector3Action.md#LateralDeadzone
+[LongitudinalDeadzone]: AxesToVector3Action.md#LongitudinalDeadzone
+[LongitudinalDeadzone]: AxesToVector3Action.md#LongitudinalDeadzone
 [Multiplier]: AxesToVector3Action.md#Multiplier
 [Multiplier]: AxesToVector3Action.md#Multiplier
 [Multiplier]: AxesToVector3Action.md#Multiplier
+[TimeMultiplier]: AxesToVector3Action.md#TimeMultiplier
+[VerticalDeadzone]: AxesToVector3Action.md#VerticalDeadzone
+[VerticalDeadzone]: AxesToVector3Action.md#VerticalDeadzone
 [Inheritance]: #Inheritance
 [Namespace]: #Namespace
 [Syntax]: #Syntax
@@ -340,6 +484,14 @@ public virtual void SetMultiplierZ(float value)
 [OnAfterVerticalAxisChange()]: #OnAfterVerticalAxisChange
 [OnAfterVerticalDeadzoneChange()]: #OnAfterVerticalDeadzoneChange
 [OnEnable()]: #OnEnable
+[SetInputType(Int32)]: #SetInputTypeInt32
+[SetLateralDeadzoneMaximum(Single)]: #SetLateralDeadzoneMaximumSingle
+[SetLateralDeadzoneMinimum(Single)]: #SetLateralDeadzoneMinimumSingle
+[SetLongitudinalDeadzoneMaximum(Single)]: #SetLongitudinalDeadzoneMaximumSingle
+[SetLongitudinalDeadzoneMinimum(Single)]: #SetLongitudinalDeadzoneMinimumSingle
 [SetMultiplierX(Single)]: #SetMultiplierXSingle
 [SetMultiplierY(Single)]: #SetMultiplierYSingle
 [SetMultiplierZ(Single)]: #SetMultiplierZSingle
+[SetTimeMultiplier(Int32)]: #SetTimeMultiplierInt32
+[SetVerticalDeadzoneMaximum(Single)]: #SetVerticalDeadzoneMaximumSingle
+[SetVerticalDeadzoneMinimum(Single)]: #SetVerticalDeadzoneMinimumSingle

--- a/Runtime/SharedResources/Scripts/AngleRangeToBooleanFacade.cs
+++ b/Runtime/SharedResources/Scripts/AngleRangeToBooleanFacade.cs
@@ -70,6 +70,81 @@
         #endregion
 
         /// <summary>
+        /// Sets the <see cref="AngleRange"/> minimum value.
+        /// </summary>
+        /// <param name="value">The new minimum value.</param>
+        public virtual void SetAngleRangeMinimum(float value)
+        {
+            FloatRange newLimit = new FloatRange(AngleRange.ToVector2());
+            newLimit.minimum = value;
+            AngleRange = newLimit;
+        }
+
+        /// <summary>
+        /// Sets the <see cref="AngleRange"/> maximum value.
+        /// </summary>
+        /// <param name="value">The new maximum value.</param>
+        public virtual void SetAngleRangeMaximum(float value)
+        {
+            FloatRange newLimit = new FloatRange(AngleRange.ToVector2());
+            newLimit.maximum = value;
+            AngleRange = newLimit;
+        }
+
+        /// <summary>
+        /// Sets <see cref="UnitType"/>.
+        /// </summary>
+        /// <param name="unitTypeIndex">The index of the <see cref="Vector2ToAngle.AngleUnit"/>.</param>
+        public virtual void SetUnitType(int unitTypeIndex)
+        {
+            UnitType = (Vector2ToAngle.AngleUnit)Mathf.Clamp(unitTypeIndex, 0, System.Enum.GetValues(typeof(Vector2ToAngle.AngleUnit)).Length);
+        }
+
+        /// <summary>
+        /// Sets the <see cref="HorizontalDeadzone"/> minimum value.
+        /// </summary>
+        /// <param name="value">The new minimum value.</param>
+        public virtual void SetHorizontalDeadzoneMinimum(float value)
+        {
+            FloatRange newLimit = new FloatRange(HorizontalDeadzone.ToVector2());
+            newLimit.minimum = value;
+            HorizontalDeadzone = newLimit;
+        }
+
+        /// <summary>
+        /// Sets the <see cref="HorizontalDeadzone"/> maximum value.
+        /// </summary>
+        /// <param name="value">The new maximum value.</param>
+        public virtual void SetHorizontalDeadzoneMaximum(float value)
+        {
+            FloatRange newLimit = new FloatRange(HorizontalDeadzone.ToVector2());
+            newLimit.maximum = value;
+            HorizontalDeadzone = newLimit;
+        }
+
+        /// <summary>
+        /// Sets the <see cref="VerticalDeadzone"/> minimum value.
+        /// </summary>
+        /// <param name="value">The new minimum value.</param>
+        public virtual void SetVerticalDeadzoneMinimum(float value)
+        {
+            FloatRange newLimit = new FloatRange(VerticalDeadzone.ToVector2());
+            newLimit.minimum = value;
+            VerticalDeadzone = newLimit;
+        }
+
+        /// <summary>
+        /// Sets the <see cref="VerticalDeadzone"/> maximum value.
+        /// </summary>
+        /// <param name="value">The new maximum value.</param>
+        public virtual void SetVerticalDeadzoneMaximum(float value)
+        {
+            FloatRange newLimit = new FloatRange(VerticalDeadzone.ToVector2());
+            newLimit.maximum = value;
+            VerticalDeadzone = newLimit;
+        }
+
+        /// <summary>
         /// Called after <see cref="AngleRange"/> has been changed.
         /// </summary>
         [CalledAfterChangeOf(nameof(AngleRange))]

--- a/Runtime/SharedResources/Scripts/AxesToAngleAction.cs
+++ b/Runtime/SharedResources/Scripts/AxesToAngleAction.cs
@@ -56,6 +56,50 @@
         public AxesToAngleActionConfigurator Configuration { get; protected set; }
         #endregion
 
+        /// <summary>
+        /// Sets the <see cref="HorizontalDeadzone"/> minimum value.
+        /// </summary>
+        /// <param name="value">The new minimum value.</param>
+        public virtual void SetHorizontalDeadzoneMinimum(float value)
+        {
+            FloatRange newLimit = new FloatRange(HorizontalDeadzone.ToVector2());
+            newLimit.minimum = value;
+            HorizontalDeadzone = newLimit;
+        }
+
+        /// <summary>
+        /// Sets the <see cref="HorizontalDeadzone"/> maximum value.
+        /// </summary>
+        /// <param name="value">The new maximum value.</param>
+        public virtual void SetHorizontalDeadzoneMaximum(float value)
+        {
+            FloatRange newLimit = new FloatRange(HorizontalDeadzone.ToVector2());
+            newLimit.maximum = value;
+            HorizontalDeadzone = newLimit;
+        }
+
+        /// <summary>
+        /// Sets the <see cref="VerticalDeadzone"/> minimum value.
+        /// </summary>
+        /// <param name="value">The new minimum value.</param>
+        public virtual void SetVerticalDeadzoneMinimum(float value)
+        {
+            FloatRange newLimit = new FloatRange(VerticalDeadzone.ToVector2());
+            newLimit.minimum = value;
+            VerticalDeadzone = newLimit;
+        }
+
+        /// <summary>
+        /// Sets the <see cref="VerticalDeadzone"/> maximum value.
+        /// </summary>
+        /// <param name="value">The new maximum value.</param>
+        public virtual void SetVerticalDeadzoneMaximum(float value)
+        {
+            FloatRange newLimit = new FloatRange(VerticalDeadzone.ToVector2());
+            newLimit.maximum = value;
+            VerticalDeadzone = newLimit;
+        }
+
         protected override void OnEnable()
         {
             base.OnEnable();

--- a/Runtime/SharedResources/Scripts/AxesToVector3Action.cs
+++ b/Runtime/SharedResources/Scripts/AxesToVector3Action.cs
@@ -100,6 +100,15 @@
         #endregion
 
         /// <summary>
+        /// Sets <see cref="InputType"/>.
+        /// </summary>
+        /// <param name="inputTypeIndex">The index of the <see cref="InputHandler"/>.</param>
+        public virtual void SetInputType(int inputTypeIndex)
+        {
+            InputType = (InputHandler)Mathf.Clamp(inputTypeIndex, 0, System.Enum.GetValues(typeof(InputHandler)).Length);
+        }
+
+        /// <summary>
         /// Sets the <see cref="Multiplier"/> x value.
         /// </summary>
         /// <param name="value">The value to set to.</param>
@@ -124,6 +133,81 @@
         public virtual void SetMultiplierZ(float value)
         {
             Multiplier = new Vector3(Multiplier.x, Multiplier.y, value);
+        }
+
+        /// <summary>
+        /// Sets <see cref="TimeMultiplier"/>.
+        /// </summary>
+        /// <param name="timeMultiplierIndex">The index of the <see cref="TimeComponentExtractor.TimeComponent"/>.</param>
+        public virtual void SetTimeMultiplier(int timeMultiplierIndex)
+        {
+            TimeMultiplier = (TimeComponentExtractor.TimeComponent)Mathf.Clamp(timeMultiplierIndex, 0, System.Enum.GetValues(typeof(TimeComponentExtractor.TimeComponent)).Length);
+        }
+
+        /// <summary>
+        /// Sets the <see cref="LateralDeadzone"/> minimum value.
+        /// </summary>
+        /// <param name="value">The new minimum value.</param>
+        public virtual void SetLateralDeadzoneMinimum(float value)
+        {
+            FloatRange newLimit = new FloatRange(LateralDeadzone.ToVector2());
+            newLimit.minimum = value;
+            LateralDeadzone = newLimit;
+        }
+
+        /// <summary>
+        /// Sets the <see cref="LateralDeadzone"/> maximum value.
+        /// </summary>
+        /// <param name="value">The new maximum value.</param>
+        public virtual void SetLateralDeadzoneMaximum(float value)
+        {
+            FloatRange newLimit = new FloatRange(LateralDeadzone.ToVector2());
+            newLimit.maximum = value;
+            LateralDeadzone = newLimit;
+        }
+
+        /// <summary>
+        /// Sets the <see cref="VerticalDeadzone"/> minimum value.
+        /// </summary>
+        /// <param name="value">The new minimum value.</param>
+        public virtual void SetVerticalDeadzoneMinimum(float value)
+        {
+            FloatRange newLimit = new FloatRange(VerticalDeadzone.ToVector2());
+            newLimit.minimum = value;
+            VerticalDeadzone = newLimit;
+        }
+
+        /// <summary>
+        /// Sets the <see cref="VerticalDeadzone"/> maximum value.
+        /// </summary>
+        /// <param name="value">The new maximum value.</param>
+        public virtual void SetVerticalDeadzoneMaximum(float value)
+        {
+            FloatRange newLimit = new FloatRange(VerticalDeadzone.ToVector2());
+            newLimit.maximum = value;
+            VerticalDeadzone = newLimit;
+        }
+
+        /// <summary>
+        /// Sets the <see cref="LongitudinalDeadzone"/> minimum value.
+        /// </summary>
+        /// <param name="value">The new minimum value.</param>
+        public virtual void SetLongitudinalDeadzoneMinimum(float value)
+        {
+            FloatRange newLimit = new FloatRange(LongitudinalDeadzone.ToVector2());
+            newLimit.minimum = value;
+            LongitudinalDeadzone = newLimit;
+        }
+
+        /// <summary>
+        /// Sets the <see cref="LongitudinalDeadzone"/> maximum value.
+        /// </summary>
+        /// <param name="value">The new maximum value.</param>
+        public virtual void SetLongitudinalDeadzoneMaximum(float value)
+        {
+            FloatRange newLimit = new FloatRange(LongitudinalDeadzone.ToVector2());
+            newLimit.maximum = value;
+            LongitudinalDeadzone = newLimit;
         }
 
         protected override void OnEnable()


### PR DESCRIPTION
A number of public properties could not be changed by UnityEvents as
the data types were not supported by the UnityEvent inspector.

This change brings in custom methods that allows changing these custom
data types via UnityEvents by providing primitive inputs.