### PR TITLE
refactor(Facade): use extension method to set enum value

### DIFF
--- a/Documentation/API/AxesToVector3Action.DeadzoneType.md
+++ b/Documentation/API/AxesToVector3Action.DeadzoneType.md
@@ -1,0 +1,35 @@
+## Contents
+
+* [Inheritance]
+* [Namespace]
+* [Syntax]
+* [Fields]
+
+## Details
+
+# Enum AxesToVector3Action.DeadzoneType
+
+The type of deadzone to apply to the input.
+
+##### Namespace
+
+* [Tilia.Input.CombinedActions]
+
+##### Syntax
+
+```
+public enum DeadzoneType
+```
+
+### Fields
+
+| Name | Description |
+| --- | --- |
+| CombinedAxis | All of the axis deadzone values are combined to form a zonal deadzone. |
+| SingleAxis | Each single axis value has its own deadzone applied independently. |
+
+[Tilia.Input.CombinedActions]: README.md
+[Inheritance]: #Inheritance
+[Namespace]: #Namespace
+[Syntax]: #Syntax
+[Fields]: #Fields

--- a/Documentation/API/AxesToVector3Action.DeadzoneType.md.meta
+++ b/Documentation/API/AxesToVector3Action.DeadzoneType.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 2212554c7f0690a4f9d077d639391230
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Documentation/API/AxesToVector3Action.md
+++ b/Documentation/API/AxesToVector3Action.md
@@ -9,6 +9,7 @@ Converts a lateral, vertical and longitudinal float representation into a Vector
 * [Syntax]
 * [Properties]
   * [Configuration]
+  * [DeadzoneCalculation]
   * [InputType]
   * [LateralAxis]
   * [LateralDeadzone]
@@ -19,6 +20,7 @@ Converts a lateral, vertical and longitudinal float representation into a Vector
   * [VerticalAxis]
   * [VerticalDeadzone]
 * [Methods]
+  * [OnAfterDeadzoneCalculationChange()]
   * [OnAfterInputTypeChange()]
   * [OnAfterLateralAxisChange()]
   * [OnAfterLateralDeadzoneChange()]
@@ -29,6 +31,7 @@ Converts a lateral, vertical and longitudinal float representation into a Vector
   * [OnAfterVerticalAxisChange()]
   * [OnAfterVerticalDeadzoneChange()]
   * [OnEnable()]
+  * [SetDeadzoneCalculation(Int32)]
   * [SetInputType(Int32)]
   * [SetLateralDeadzoneMaximum(Single)]
   * [SetLateralDeadzoneMinimum(Single)]
@@ -68,6 +71,16 @@ The linked Internal Setup.
 
 ```
 public AxesToVector3ActionConfigurator Configuration { get; protected set; }
+```
+
+#### DeadzoneCalculation
+
+The way in which the deadzone is calculated by the input axes.
+
+##### Declaration
+
+```
+public AxesToVector3Action.DeadzoneType DeadzoneCalculation { get; set; }
 ```
 
 #### InputType
@@ -161,6 +174,16 @@ public FloatRange VerticalDeadzone { get; set; }
 ```
 
 ### Methods
+
+#### OnAfterDeadzoneCalculationChange()
+
+Called after [DeadzoneCalculation] has been changed.
+
+##### Declaration
+
+```
+protected virtual void OnAfterDeadzoneCalculationChange()
+```
 
 #### OnAfterInputTypeChange()
 
@@ -259,6 +282,22 @@ protected virtual void OnAfterVerticalDeadzoneChange()
 ```
 protected override void OnEnable()
 ```
+
+#### SetDeadzoneCalculation(Int32)
+
+Sets [DeadzoneCalculation].
+
+##### Declaration
+
+```
+public virtual void SetDeadzoneCalculation(int deadzoneTypeIndex)
+```
+
+##### Parameters
+
+| Type | Name | Description |
+| --- | --- | --- |
+| System.Int32 | deadzoneTypeIndex | The index of the [AxesToVector3Action.DeadzoneType]. |
 
 #### SetInputType(Int32)
 
@@ -438,6 +477,7 @@ public virtual void SetVerticalDeadzoneMinimum(float value)
 
 [Tilia.Input.CombinedActions]: README.md
 [AxesToVector3ActionConfigurator]: AxesToVector3ActionConfigurator.md
+[DeadzoneCalculation]: AxesToVector3Action.md#DeadzoneCalculation
 [InputType]: AxesToVector3Action.md#InputType
 [LateralAxis]: AxesToVector3Action.md#LateralAxis
 [LateralDeadzone]: AxesToVector3Action.md#LateralDeadzone
@@ -447,6 +487,8 @@ public virtual void SetVerticalDeadzoneMinimum(float value)
 [TimeMultiplier]: AxesToVector3Action.md#TimeMultiplier
 [VerticalAxis]: AxesToVector3Action.md#VerticalAxis
 [VerticalDeadzone]: AxesToVector3Action.md#VerticalDeadzone
+[DeadzoneCalculation]: AxesToVector3Action.md#DeadzoneCalculation
+[AxesToVector3Action.DeadzoneType]: AxesToVector3Action.DeadzoneType.md
 [InputType]: AxesToVector3Action.md#InputType
 [AxesToVector3Action.InputHandler]: AxesToVector3Action.InputHandler.md
 [LateralDeadzone]: AxesToVector3Action.md#LateralDeadzone
@@ -464,6 +506,7 @@ public virtual void SetVerticalDeadzoneMinimum(float value)
 [Syntax]: #Syntax
 [Properties]: #Properties
 [Configuration]: #Configuration
+[DeadzoneCalculation]: #DeadzoneCalculation
 [InputType]: #InputType
 [LateralAxis]: #LateralAxis
 [LateralDeadzone]: #LateralDeadzone
@@ -474,6 +517,7 @@ public virtual void SetVerticalDeadzoneMinimum(float value)
 [VerticalAxis]: #VerticalAxis
 [VerticalDeadzone]: #VerticalDeadzone
 [Methods]: #Methods
+[OnAfterDeadzoneCalculationChange()]: #OnAfterDeadzoneCalculationChange
 [OnAfterInputTypeChange()]: #OnAfterInputTypeChange
 [OnAfterLateralAxisChange()]: #OnAfterLateralAxisChange
 [OnAfterLateralDeadzoneChange()]: #OnAfterLateralDeadzoneChange
@@ -484,6 +528,7 @@ public virtual void SetVerticalDeadzoneMinimum(float value)
 [OnAfterVerticalAxisChange()]: #OnAfterVerticalAxisChange
 [OnAfterVerticalDeadzoneChange()]: #OnAfterVerticalDeadzoneChange
 [OnEnable()]: #OnEnable
+[SetDeadzoneCalculation(Int32)]: #SetDeadzoneCalculationInt32
 [SetInputType(Int32)]: #SetInputTypeInt32
 [SetLateralDeadzoneMaximum(Single)]: #SetLateralDeadzoneMaximumSingle
 [SetLateralDeadzoneMinimum(Single)]: #SetLateralDeadzoneMinimumSingle

--- a/Documentation/API/AxesToVector3ActionConfigurator.md
+++ b/Documentation/API/AxesToVector3ActionConfigurator.md
@@ -10,6 +10,7 @@ Sets up the AxesToVector3Action prefab based on the provided user settings.
 * [Properties]
   * [AutoConfigureBounds]
   * [BoundOverlap]
+  * [CombinedAxisDeadzoneContainer]
   * [DirectionalContainer]
   * [IncrementalContainer]
   * [LateralAction]
@@ -23,6 +24,7 @@ Sets up the AxesToVector3Action prefab based on the provided user settings.
   * [LongitudinalNegativeBounds]
   * [LongitudinalPositiveBounds]
   * [Multiplier]
+  * [SingleAxisDeadzoneContainer]
   * [TimeExtractor]
   * [VerticalAction]
   * [VerticalBoundsManager]
@@ -30,7 +32,8 @@ Sets up the AxesToVector3Action prefab based on the provided user settings.
   * [VerticalNegativeBounds]
   * [VerticalPositiveBounds]
 * [Methods]
-  * [SetBounds(FloatRange, FloatToBoolean, FloatToBoolean, FloatToBoolean, FloatToBoolean)]
+  * [SetBounds(FloatRange, FloatToBoolean\[\], FloatToBoolean, FloatToBoolean, FloatToBoolean)]
+  * [SetDeadzoneCalculation(AxesToVector3Action.DeadzoneType)]
   * [SetInputSource(FloatAction, FloatAction)]
   * [SetInputType(AxesToVector3Action.InputHandler)]
   * [SetLateralAxisSource(FloatAction)]
@@ -81,6 +84,16 @@ The value to overlap the directional input bounds by.
 public float BoundOverlap { get; set; }
 ```
 
+#### CombinedAxisDeadzoneContainer
+
+The container that holds the combined axis deadzone logic.
+
+##### Declaration
+
+```
+public GameObject CombinedAxisDeadzoneContainer { get; set; }
+```
+
 #### DirectionalContainer
 
 The container that holds the directional input logic.
@@ -128,7 +141,7 @@ The lateral deadzone controller.
 ##### Declaration
 
 ```
-public FloatToBoolean LateralDeadZone { get; set; }
+public FloatToBoolean[] LateralDeadZone { get; set; }
 ```
 
 #### LateralNegativeBounds
@@ -178,7 +191,7 @@ The longitudinal deadzone controller.
 ##### Declaration
 
 ```
-public FloatToBoolean LongitudinalDeadZone { get; set; }
+public FloatToBoolean[] LongitudinalDeadZone { get; set; }
 ```
 
 #### LongitudinalNegativeBounds
@@ -209,6 +222,16 @@ The collection used to multiply the output Vector3.
 
 ```
 public Vector3ObservableList Multiplier { get; set; }
+```
+
+#### SingleAxisDeadzoneContainer
+
+The container that holds the single axis deadzone logic.
+
+##### Declaration
+
+```
+public GameObject SingleAxisDeadzoneContainer { get; set; }
 ```
 
 #### TimeExtractor
@@ -248,7 +271,7 @@ The vertical deadzone controller.
 ##### Declaration
 
 ```
-public FloatToBoolean VerticalDeadZone { get; set; }
+public FloatToBoolean[] VerticalDeadZone { get; set; }
 ```
 
 #### VerticalNegativeBounds
@@ -273,14 +296,14 @@ public FloatToBoolean VerticalPositiveBounds { get; set; }
 
 ### Methods
 
-#### SetBounds(FloatRange, FloatToBoolean, FloatToBoolean, FloatToBoolean, FloatToBoolean)
+#### SetBounds(FloatRange, FloatToBoolean\[\], FloatToBoolean, FloatToBoolean, FloatToBoolean)
 
 Sets the boundary data for the input.
 
 ##### Declaration
 
 ```
-protected virtual void SetBounds(FloatRange newBounds, FloatToBoolean deadzone, FloatToBoolean positiveBounds, FloatToBoolean negativeBounds, FloatToBoolean boundsManager)
+protected virtual void SetBounds(FloatRange newBounds, FloatToBoolean[] deadzone, FloatToBoolean positiveBounds, FloatToBoolean negativeBounds, FloatToBoolean boundsManager)
 ```
 
 ##### Parameters
@@ -288,10 +311,26 @@ protected virtual void SetBounds(FloatRange newBounds, FloatToBoolean deadzone, 
 | Type | Name | Description |
 | --- | --- | --- |
 | FloatRange | newBounds | Thew new range for the bounds. |
-| FloatToBoolean | deadzone | The axis deadzone to set. |
+| FloatToBoolean\[\] | deadzone | The axis deadzone to set. |
 | FloatToBoolean | positiveBounds | The axis positive bounds to set. |
 | FloatToBoolean | negativeBounds | The axis negative bounds to set. |
 | FloatToBoolean | boundsManager | The axis bounds manager to set. |
+
+#### SetDeadzoneCalculation(AxesToVector3Action.DeadzoneType)
+
+Enables the appropriate Deadzone Calculation logic.
+
+##### Declaration
+
+```
+public virtual void SetDeadzoneCalculation(AxesToVector3Action.DeadzoneType deadzoneType)
+```
+
+##### Parameters
+
+| Type | Name | Description |
+| --- | --- | --- |
+| [AxesToVector3Action.DeadzoneType] | deadzoneType | The type of deadzone to use. |
 
 #### SetInputSource(FloatAction, FloatAction)
 
@@ -455,6 +494,7 @@ public virtual void SetVerticalDeadzone(FloatRange deadzone)
 | FloatRange | deadzone | The deadzone range to set to. |
 
 [Tilia.Input.CombinedActions]: README.md
+[AxesToVector3Action.DeadzoneType]: AxesToVector3Action.DeadzoneType.md
 [AxesToVector3Action.InputHandler]: AxesToVector3Action.InputHandler.md
 [LateralAction]: AxesToVector3ActionConfigurator.md#LateralAction
 [LongitudinalAction]: AxesToVector3ActionConfigurator.md#LongitudinalAction
@@ -465,6 +505,7 @@ public virtual void SetVerticalDeadzone(FloatRange deadzone)
 [Properties]: #Properties
 [AutoConfigureBounds]: #AutoConfigureBounds
 [BoundOverlap]: #BoundOverlap
+[CombinedAxisDeadzoneContainer]: #CombinedAxisDeadzoneContainer
 [DirectionalContainer]: #DirectionalContainer
 [IncrementalContainer]: #IncrementalContainer
 [LateralAction]: #LateralAction
@@ -478,6 +519,7 @@ public virtual void SetVerticalDeadzone(FloatRange deadzone)
 [LongitudinalNegativeBounds]: #LongitudinalNegativeBounds
 [LongitudinalPositiveBounds]: #LongitudinalPositiveBounds
 [Multiplier]: #Multiplier
+[SingleAxisDeadzoneContainer]: #SingleAxisDeadzoneContainer
 [TimeExtractor]: #TimeExtractor
 [VerticalAction]: #VerticalAction
 [VerticalBoundsManager]: #VerticalBoundsManager
@@ -485,7 +527,8 @@ public virtual void SetVerticalDeadzone(FloatRange deadzone)
 [VerticalNegativeBounds]: #VerticalNegativeBounds
 [VerticalPositiveBounds]: #VerticalPositiveBounds
 [Methods]: #Methods
-[SetBounds(FloatRange, FloatToBoolean, FloatToBoolean, FloatToBoolean, FloatToBoolean)]: #SetBoundsFloatRange-FloatToBoolean-FloatToBoolean-FloatToBoolean-FloatToBoolean
+[SetBounds(FloatRange, FloatToBoolean\[\], FloatToBoolean, FloatToBoolean, FloatToBoolean)]: #SetBoundsFloatRange-FloatToBoolean\[\]-FloatToBoolean-FloatToBoolean-FloatToBoolean
+[SetDeadzoneCalculation(AxesToVector3Action.DeadzoneType)]: #SetDeadzoneCalculationAxesToVector3Action.DeadzoneType
 [SetInputSource(FloatAction, FloatAction)]: #SetInputSourceFloatAction-FloatAction
 [SetInputType(AxesToVector3Action.InputHandler)]: #SetInputTypeAxesToVector3Action.InputHandler
 [SetLateralAxisSource(FloatAction)]: #SetLateralAxisSourceFloatAction

--- a/Documentation/API/README.md
+++ b/Documentation/API/README.md
@@ -32,6 +32,10 @@ Sets up the BooleanTo1DAxisAction prefab based on the provided user settings.
 
 ### Enums
 
+#### [AxesToVector3Action.DeadzoneType]
+
+The type of deadzone to apply to the input.
+
 #### [AxesToVector3Action.InputHandler]
 
 The way the input is handled.
@@ -44,4 +48,5 @@ The way the input is handled.
 [AxesToVector3ActionConfigurator]: AxesToVector3ActionConfigurator.md
 [BooleanTo1DAxisAction]: BooleanTo1DAxisAction.md
 [BooleanTo1DAxisActionConfigurator]: BooleanTo1DAxisActionConfigurator.md
+[AxesToVector3Action.DeadzoneType]: AxesToVector3Action.DeadzoneType.md
 [AxesToVector3Action.InputHandler]: AxesToVector3Action.InputHandler.md

--- a/Runtime/SharedResources/Scripts/AngleRangeToBooleanFacade.cs
+++ b/Runtime/SharedResources/Scripts/AngleRangeToBooleanFacade.cs
@@ -9,6 +9,7 @@
     using Zinnia.Data.Attribute;
     using Zinnia.Data.Type;
     using Zinnia.Data.Type.Transformation.Conversion;
+    using Zinnia.Extension;
 
     /// <summary>
     /// The public interface into the AngleRangeToBoolean Prefab.
@@ -97,7 +98,7 @@
         /// <param name="unitTypeIndex">The index of the <see cref="Vector2ToAngle.AngleUnit"/>.</param>
         public virtual void SetUnitType(int unitTypeIndex)
         {
-            UnitType = (Vector2ToAngle.AngleUnit)Mathf.Clamp(unitTypeIndex, 0, System.Enum.GetValues(typeof(Vector2ToAngle.AngleUnit)).Length);
+            UnitType = EnumExtensions.GetByIndex<Vector2ToAngle.AngleUnit>(unitTypeIndex);
         }
 
         /// <summary>

--- a/Runtime/SharedResources/Scripts/AxesToVector3Action.cs
+++ b/Runtime/SharedResources/Scripts/AxesToVector3Action.cs
@@ -9,6 +9,7 @@
     using Zinnia.Data.Attribute;
     using Zinnia.Data.Operation.Extraction;
     using Zinnia.Data.Type;
+    using Zinnia.Extension;
 
     /// <summary>
     /// Converts a lateral, vertical and longitudinal float representation into a Vector3 action.
@@ -162,7 +163,7 @@
         /// <param name="timeMultiplierIndex">The index of the <see cref="TimeComponentExtractor.TimeComponent"/>.</param>
         public virtual void SetTimeMultiplier(int timeMultiplierIndex)
         {
-            TimeMultiplier = (TimeComponentExtractor.TimeComponent)Mathf.Clamp(timeMultiplierIndex, 0, System.Enum.GetValues(typeof(TimeComponentExtractor.TimeComponent)).Length);
+            TimeMultiplier = EnumExtensions.GetByIndex<TimeComponentExtractor.TimeComponent>(timeMultiplierIndex);
         }
 
         /// <summary>


### PR DESCRIPTION
The SetUnitType and SetTimeMultiplier methods now uses the Zinnia
EnumExtensions helper method to set the value of the enum by the
index instead of repeating the same logic.